### PR TITLE
Sanitizing user input

### DIFF
--- a/RelativePath.Example1.php
+++ b/RelativePath.Example1.php
@@ -82,12 +82,13 @@ print "<p>docRoot: $docRoot</p>\n";
 <form method="post">
 <p>Path:<br />
 <input type="text" size="120" name="path"
-	value="<?php echo stripslashes($_POST['path']); ?>" /></p>
+	value="<?php echo htmlspecialchars(stripslashes($_POST['path']), ENT_QUOTES); ?>" /></p>
 <p><input type="submit" /></p>
 </form>
 <dl>
 <?php
 foreach ($paths as $path) {
+    $path = htmlspecialchars($path, ENT_QUOTES);
 	echo "<dt><pre>Path '$path' becomes:</pre></dt>\n";
 	echo "<dd><pre>";
 	echo "'" . RelativePath::getRelativePath($path) . "'\n";


### PR DESCRIPTION
While it would be nice if we could trust people not to include example files on live servers, a google search will reveal many people are serving RelativePath.Example1.php, including anyone running a here-unnamed CMS which includes this file in a subdirectory of the webroot.

The proposed changes simply escape the user input, closing an xss vulnerability.